### PR TITLE
chore(example): adding docker compose to run examples

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -19,3 +19,4 @@ ignorePaths:
   - '*.css'
   - '*.svg'
   - '*/**Makefile'
+  - '**/target'

--- a/.cspell.project-words.txt
+++ b/.cspell.project-words.txt
@@ -21,3 +21,5 @@ unoptimized
 yapf
 yeahhhhh
 Vertiport
+healthcheck
+workdir

--- a/.github/workflows/build-and-push-docker.yml
+++ b/.github/workflows/build-and-push-docker.yml
@@ -37,7 +37,7 @@ jobs:
             ./${{ matrix.path }}/.cargo/registry/cache/
             ./${{ matrix.path }}/.cargo/git/db/
             ./${{ matrix.path }}/target/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server-web/**') }}
           restore-keys: ${{ runner.os }}-cargo-
 
       - name: Dotenv Action

--- a/.github/workflows/rust_ci.yml
+++ b/.github/workflows/rust_ci.yml
@@ -20,6 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ./server-web/.cargo/bin/
+            ./server-web/.cargo/registry/index/
+            ./server-web/.cargo/registry/cache/
+            ./server-web/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server-web/**') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - run: make rust-check
 
   build_and_test_debug:
@@ -27,6 +38,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ./server-web/.cargo/bin/
+            ./server-web/.cargo/registry/index/
+            ./server-web/.cargo/registry/cache/
+            ./server-web/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server-web/**') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - name: Build
         run: make build
       - name: Test
@@ -38,6 +60,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ./server-web/.cargo/bin/
+            ./server-web/.cargo/registry/index/
+            ./server-web/.cargo/registry/cache/
+            ./server-web/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server-web/**') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - run: make rust-fmt
 
   clippy:
@@ -45,4 +78,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up cargo cache
+        uses: actions/cache@v3
+        continue-on-error: false
+        with:
+          path: |
+            ./server-web/.cargo/bin/
+            ./server-web/.cargo/registry/index/
+            ./server-web/.cargo/registry/cache/
+            ./server-web/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('server-web/**') }}
+          restore-keys: ${{ runner.os }}-cargo-
       - run: make rust-clippy

--- a/.make/rust.mk
+++ b/.make/rust.mk
@@ -35,7 +35,7 @@ endif
 
 # Rust / cargo targets
 check-cargo-registry:
-	if [ ! -d "$(PWD)/.cargo/registry" ]; then mkdir -p "$(PWD)/.cargo/registry" ; fi
+	if [ ! -d "$(SOURCE_PATH).cargo/registry" ]; then mkdir -p "$(SOURCE_PATH).cargo/registry" ; fi
 
 .SILENT: check-cargo-registry docker-pull
 

--- a/.make/rust.mk
+++ b/.make/rust.mk
@@ -35,7 +35,7 @@ endif
 
 # Rust / cargo targets
 check-cargo-registry:
-	if [ ! -d "$(SOURCE_PATH).cargo/registry" ]; then mkdir -p "$(SOURCE_PATH).cargo/registry" ; fi
+	if [ ! -d "$(PWD)/.cargo/registry" ]; then mkdir -p "$(PWD)/.cargo/registry" ; fi
 
 .SILENT: check-cargo-registry docker-pull
 

--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,4 @@ rust-%:
 python-%:
 	cd ./server-web && $(MAKE) $@
 
-test: rust-test-all toml-test python-test md-test-links editorconfig-test
+test: rust-test-all toml-test python-test cspell-test md-test-links editorconfig-test

--- a/server-web/README.md
+++ b/server-web/README.md
@@ -13,16 +13,17 @@ make docker-run # server starts immediately
 docker ps # confirm the container is running
 ```
 
-Run the integration test (`endpoints.rs`) for a sanity check:
-```bash
-make example
-```
-
 To kill the container:
 ```bash
 # Kill container
 make docker-stop
 ```
+
+Run the integration test (`endpoints.rs`) for a sanity check:
+```bash
+make example
+```
+This will automatically start the server, run cargo example, and stop the server using `docker compose`.
 
 ## Required Endpoints
 

--- a/server-web/actix-rest/Makefile
+++ b/server-web/actix-rest/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-SOURCE_PATH = "$(PWD)/../"
+SOURCE_PATH = $(PWD)/../
 
 help: .help-base .help-rust .help-docker
 

--- a/server-web/actix-rest/examples/endpoints.rs
+++ b/server-web/actix-rest/examples/endpoints.rs
@@ -5,10 +5,5 @@ use common_example;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // URL from another docker container on a network bridge
-    let url: &str = "http://arrow-benchmarks-actix-rest-run:8000";
-    // URL from host
-    // let url: &str = "http://localhost:8080"; // from localhost
-
-    common_example::test_rest_endpoints(url).await
+    common_example::test_rest_endpoints().await
 }

--- a/server-web/axum-graphql/Makefile
+++ b/server-web/axum-graphql/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-SOURCE_PATH = "$(PWD)/../"
+SOURCE_PATH = $(PWD)/../
 
 help: .help-base .help-rust .help-docker
 

--- a/server-web/axum-rest/Makefile
+++ b/server-web/axum-rest/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-SOURCE_PATH = "$(PWD)/../"
+SOURCE_PATH = $(PWD)/../
 
 help: .help-base .help-rust .help-docker
 

--- a/server-web/axum-rest/examples/endpoints.rs
+++ b/server-web/axum-rest/examples/endpoints.rs
@@ -5,10 +5,5 @@ use common_example;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // URL from another docker container on a network bridge
-    let url: &str = "http://arrow-benchmarks-axum-rest-run:8000";
-    // URL from host
-    // let url: &str = "http://localhost:8080"; // from localhost
-
-    common_example::test_rest_endpoints(url).await
+    common_example::test_rest_endpoints().await
 }

--- a/server-web/common-example/src/lib.rs
+++ b/server-web/common-example/src/lib.rs
@@ -4,15 +4,42 @@ use axum::http::StatusCode;
 use chrono::NaiveDate;
 use common_rest::FlightInput;
 use hyper::{Body, Client, Method, Request};
+use std::env;
 use std::time::Duration;
+
+/// Provide endpoint url to use
+pub fn get_endpoint() -> String {
+    // Set default hostname and port
+    let mut hostname = "localhost".to_string();
+    let mut port = "8080".to_string();
+
+    // Allow override of hostname and port through env vars
+    if env::var("HOSTNAME").is_ok() {
+        if let Ok(v) = env::var("HOSTNAME") {
+            hostname = v
+        }
+    }
+    if env::var("DOCKER_PORT").is_ok() {
+        if let Ok(v) = env::var("DOCKER_PORT") {
+            port = v
+        }
+    }
+
+    format!("http://{}:{}", hostname, port)
+}
 
 /// Lightly exercise the following endpoints:
 /// - /100
 /// - /1000
 /// - /fetch-flights
 /// - /create-flight
-pub async fn test_rest_endpoints(url: &str) -> Result<(), Box<dyn std::error::Error>> {
-    println!("NOTE: Ensure the server is running, or this example will fail.");
+pub async fn test_rest_endpoints() -> Result<(), Box<dyn std::error::Error>> {
+    let url: &str = &get_endpoint();
+
+    println!(
+        "NOTE: Ensure the server is running on {} or this example will fail.",
+        url
+    );
 
     let mut ok = true;
     let client = Client::builder()

--- a/server-web/docker-compose.yml
+++ b/server-web/docker-compose.yml
@@ -1,0 +1,32 @@
+---
+version: '3.6'
+services:
+  web-server:
+    container_name: ${PACKAGE_NAME}-run
+    image: ${IMAGE_NAME}:latest
+    ports:
+      - ${HOST_PORT}:${DOCKER_PORT}
+    healthcheck:
+      test: |
+        bash -c 'exec 3<> /dev/tcp/127.0.0.1/8080 && echo -e "GET /available-flights HTTP/1.1\r\nAccept: application/json\r\n\r\n" >&3 && head -3 <&3 | grep "200 OK"'
+      interval: 30s
+      timeout: 10s
+      retries: 6
+      start_period: 10s
+
+  example:
+    links:
+      - web-server
+    container_name: ${PACKAGE_NAME}-example
+    image: ${BUILD_IMAGE_NAME}:${BUILD_IMAGE_TAG}
+    volumes:
+      - type: bind
+        source: "${SOURCE_PATH}/"
+        target: "/usr/src/app"
+      - type: bind
+        source: "${SOURCE_PATH}/.cargo/registry"
+        target: "/usr/local/cargo/registry"
+    environment:
+      - HOSTNAME
+      - DOCKER_PORT
+    command: cargo run --manifest-path "${CARGO_MANIFEST_PATH}" --example endpoints

--- a/server-web/docker-compose.yml
+++ b/server-web/docker-compose.yml
@@ -7,16 +7,17 @@ services:
     ports:
       - ${HOST_PORT}:${DOCKER_PORT}
     healthcheck:
-      test: |
-        bash -c 'exec 3<> /dev/tcp/127.0.0.1/8080 && echo -e "GET /available-flights HTTP/1.1\r\nAccept: application/json\r\n\r\n" >&3 && head -3 <&3 | grep "200 OK"'
-      interval: 30s
-      timeout: 10s
-      retries: 6
-      start_period: 10s
+      test: ["CMD", "wget", "--spider", "--no-verbose", "--tries=1", "http://localhost:${DOCKER_PORT}/fetch-flights"]
+      interval: 2s
+      timeout: 1s
+      retries: 3
 
   example:
     links:
       - web-server
+    depends_on:
+      web-server:
+        condition: service_healthy
     container_name: ${PACKAGE_NAME}-example
     image: ${BUILD_IMAGE_NAME}:${BUILD_IMAGE_TAG}
     volumes:

--- a/server-web/poem-rest/Makefile
+++ b/server-web/poem-rest/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-SOURCE_PATH = "$(PWD)/../"
+SOURCE_PATH = $(PWD)/../
 
 help: .help-base .help-rust .help-docker
 

--- a/server-web/poem-rest/examples/endpoints.rs
+++ b/server-web/poem-rest/examples/endpoints.rs
@@ -5,10 +5,5 @@ use common_example;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // URL from another docker container on a network bridge
-    let url: &str = "http://arrow-benchmarks-poem-rest-run:8000";
-    // URL from host
-    // let url: &str = "http://localhost:8080"; // from localhost
-
-    common_example::test_rest_endpoints(url).await
+    common_example::test_rest_endpoints().await
 }

--- a/server-web/targets-server-web.mk
+++ b/server-web/targets-server-web.mk
@@ -13,4 +13,4 @@ example: check-cargo-registry docker-pull
 		--rm \
 		-e CARGO_INCREMENTAL=1 \
 		-e RUSTC_BOOTSTRAP=0 \
-		example
+		example && docker compose stop

--- a/server-web/targets-server-web.mk
+++ b/server-web/targets-server-web.mk
@@ -1,5 +1,16 @@
-DOCKER_BUILD_PATH=../
-DOCKER_NAME=arrow-$(PACKAGE_NAME)
+DOCKER_BUILD_PATH = ../
+DOCKER_NAME       = arrow-$(PACKAGE_NAME)
+DOCKER_PORT       = 8000
+HOST_PORT         = 8080
+HOSTNAME          = $(PACKAGE_NAME)-run
 
 example: check-cargo-registry docker-pull
-	@$(call cargo_run,run --example endpoints)
+	@docker compose \
+		-f ../docker-compose.yml \
+		run \
+		--workdir=/usr/src/app/${PACKAGE_NAME} \
+		--user `id -u`:`id -g` \
+		--rm \
+		-e CARGO_INCREMENTAL=1 \
+		-e RUSTC_BOOTSTRAP=0 \
+		example


### PR DESCRIPTION
Now using `docker compose` to make sure our server is running and healthy before running our examples.
Also added a `get_endpoint` function to `common-example` to determine the URL based on environment variables. This will default to http://localhost:8080, so we should be able to run the examples locally as well.